### PR TITLE
Control the polyphony, unify audio playback

### DIFF
--- a/MpcMaid/src/com/mpcmaid/audio/AudioWorker.java
+++ b/MpcMaid/src/com/mpcmaid/audio/AudioWorker.java
@@ -1,0 +1,78 @@
+package com.mpcmaid.audio;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
+
+/**
+ * A sample-playing thread which uses single dataline to play samples.
+ */
+public class AudioWorker extends Thread {
+
+	private final BlockingQueue<Sample> clipQueue;
+
+	AudioWorker(BlockingQueue<Sample> queue) {
+		this.clipQueue = queue;
+	}
+
+	/**
+	 * Plays the queued clips, closing the
+	 * data line if no new AudioClips are fetched within a certain (short)
+	 * period of time.
+	 */
+	public void run() {
+		SourceDataLine dataLine = null;
+		while (true) {
+			try {
+				Sample sample;
+				try {
+					sample = (Sample) clipQueue.poll(5, TimeUnit.SECONDS);
+					if (sample == null) {
+						if (dataLine != null && dataLine.isOpen() && !dataLine.isRunning()) {
+							dataLine.close();
+							dataLine = null;
+						}
+						continue;
+					}
+				} catch (InterruptedException e) {
+					if (dataLine != null && dataLine.isOpen() && !dataLine.isRunning()) {
+						dataLine.close();
+						dataLine = null;
+					}
+					continue;
+				}
+				AudioFormat format = sample.getFormat();
+				if (dataLine == null) {
+					DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
+					dataLine = (SourceDataLine) AudioSystem.getLine(info);
+				}
+
+				if (!format.matches(dataLine.getFormat())) {
+					dataLine.close();
+					DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
+					dataLine = (SourceDataLine) AudioSystem.getLine(info);
+				}
+
+				if (!dataLine.isOpen())
+					dataLine.open(format);
+
+				if (!dataLine.isRunning())
+					dataLine.start();
+
+				dataLine.write(sample.getBytes(), 0, sample.getBytes().length);
+				//dataLine.close();
+			} catch (LineUnavailableException e) {
+				e.printStackTrace();
+			} catch (IllegalArgumentException e) {
+				e.printStackTrace();
+			} catch (Throwable t) {
+				t.printStackTrace();
+			}
+		}
+	}
+}

--- a/MpcMaid/src/com/mpcmaid/audio/Sample.java
+++ b/MpcMaid/src/com/mpcmaid/audio/Sample.java
@@ -38,9 +38,6 @@ public class Sample {
 	}
 
 	private static Sample open(final AudioInputStream audioStream) throws LineUnavailableException, IOException {
-		final DataLine.Info info = new DataLine.Info(SourceDataLine.class, audioStream.getFormat());
-		final SourceDataLine line = (SourceDataLine) AudioSystem.getLine(info);
-
 		final int frameLength = (int) audioStream.getFrameLength();
 		if (frameLength > 44100 * 8 * 2) {
 			throw new IllegalArgumentException("The audio file is too long (must be shorter than 4 bars at 50BPM)");
@@ -48,31 +45,18 @@ public class Sample {
 		final AudioFormat format = audioStream.getFormat();
 		final int frameSize = (int) format.getFrameSize();
 		final byte[] bytes = new byte[frameLength * frameSize];
-		line.open(format);
-		line.start();
 		final int result = audioStream.read(bytes);
 		if (result < 0) {
 			return null;
 		}
 
-		line.drain();
-		line.close();
 		audioStream.close();
 
 		return new Sample(bytes, format, frameLength);
 	}
 
 	public void play() throws Exception {
-		final DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
-		final SourceDataLine line = (SourceDataLine) AudioSystem.getLine(info);
-
-		line.open(format);
-		line.start();
-
-		line.write(bytes, 0, bytes.length);
-
-		line.drain();
-		line.close();
+		SamplePlayer.getInstance().play(this);
 	}
 
 	public void save(File file) throws Exception {

--- a/MpcMaid/src/com/mpcmaid/audio/SamplePlayer.java
+++ b/MpcMaid/src/com/mpcmaid/audio/SamplePlayer.java
@@ -1,43 +1,47 @@
 package com.mpcmaid.audio;
 
-import java.applet.AudioClip;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
-import com.sun.media.sound.JavaSoundAudioClip;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 
 /**
- * A sample player based on the SoundManager (multithread audio player)
- * 
+ * An sample player which employs limited number of threads to play clips. Each
+ * thread creates it's own dataLine.
+ *
  * @pattern Singleton We only need one sample player for every window, so that
  *          to control the overall polyphony.
- * 
- * @author cyrille martraire
+ *
  */
 public final class SamplePlayer {
 
 	private final static SamplePlayer INSTANCE = new SamplePlayer();
 
+	private final static BlockingQueue<Sample> queue = new ArrayBlockingQueue<Sample>(1);
+
+	static {
+		// only six sounds can be heard at once
+		int numWorkers = 6;
+		AudioWorker[] workers = new AudioWorker[numWorkers];
+		for (int i = 0; i < workers.length; i++) {
+			workers[i] = new AudioWorker(queue);
+			workers[i].start();
+		}
+	}
+
 	public static SamplePlayer getInstance() {
 		return INSTANCE;
 	}
 
-	public void play(File file) {
-		AudioClip clip;
-		try {
-			final FileInputStream fis = new FileInputStream(file);
-			clip = new JavaSoundAudioClip(fis);
-			clip.play();
+	public void play(Sample sample) {
+		if (queue.isEmpty())
+			queue.add(sample);
+	}
 
-			// supposed to free the data line...
-			clip = null;
-			fis.close();
-			//System.gc();
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
+	public void play(File file) {
+		try {
+			if (queue.isEmpty())
+				queue.add(Sample.open(file));
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
Fix problems with audio. Originally, the app created new dataLine everytime it played a sound and left these lines opened. This especially caused crashes on systems with PulseAudio (Linux and similar).

Currently, limited number of threads (six) plays the audio whenever they're ready and releases the data line after stopping.

This limits the number of playing sounds to 6 at time.
